### PR TITLE
Potential fix for code scanning alert no. 2: Server-side request forgery

### DIFF
--- a/server.js
+++ b/server.js
@@ -11,6 +11,10 @@ app.use(express.json());
 app.get('/weather/:city', async (req, res) => {
   try {
     const city = req.params.city;
+    const validCities = ['New York', 'London', 'Paris', 'Tokyo', 'Sydney']; // Example allow-list
+    if (!validCities.includes(city)) {
+      return res.status(400).json({ error: 'Invalid city name' });
+    }
     const response = await axios.get(`https://wttr.in/${city}?format=j1`);
     const data = response.data;
     res.json({


### PR DESCRIPTION
Potential fix for [https://github.com/johntoby/city-weather-application/security/code-scanning/2](https://github.com/johntoby/city-weather-application/security/code-scanning/2)

To fix the SSRF vulnerability, we will validate the `city` parameter against a predefined allow-list of acceptable city names. This ensures that only known, valid city names can be used in the request. If the user provides a city name not in the allow-list, the server will return an error response. This approach prevents malicious input from being used to construct the URL.

Steps to implement the fix:
1. Define an allow-list of valid city names.
2. Check if the `city` parameter matches an entry in the allow-list.
3. If the `city` is valid, proceed with the request; otherwise, return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
